### PR TITLE
[Mock][Suggestion] Debug web interface using Flask HTML templates

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,6 +8,7 @@ import logging
 from src.test import test_routes
 from src.openai import openai_routes
 from src.assessment import assessment_routes
+from src.templates import template_routes
 
 # Flask
 from flask import Flask
@@ -51,5 +52,6 @@ def create_app(test_config=None):
     app.register_blueprint(test_routes)
     app.register_blueprint(openai_routes)
     app.register_blueprint(assessment_routes)
+    app.register_blueprint(template_routes)
 
     return app

--- a/src/templates.py
+++ b/src/templates.py
@@ -1,0 +1,31 @@
+# These routes (/htmx and the root /) issue HTML from the /templates directory.
+# / to templates/index.html
+# /htmx/authorized to templates/authorized.html
+# /htmx/grading to templates/grading.html
+
+from flask import Blueprint, request, render_template
+
+import os
+import openai
+import json
+
+template_routes = Blueprint('template_routes', __name__)
+
+@template_routes.route("/debug_interface")
+def debug_interface_html():
+    with open('test/data/u3l23_01.js', 'r') as f:
+        code = f.read()
+
+    with open('test/data/u3l23.txt', 'r') as f:
+        prompt = f.read()
+
+    with open('test/data/u3l23.csv', 'r') as f:
+        rubric = f.read()
+        
+    return render_template(
+        "debug_interface.html",
+        code=code,
+        prompt=prompt,
+        rubric=rubric,
+    )
+

--- a/src/templates.py
+++ b/src/templates.py
@@ -1,7 +1,5 @@
-# These routes (/htmx and the root /) issue HTML from the /templates directory.
-# / to templates/index.html
-# /htmx/authorized to templates/authorized.html
-# /htmx/grading to templates/grading.html
+# These routes issue HTML from HTML templates in the /templates directory.
+# /debug_interface renders templates/debug_interface.html
 
 from flask import Blueprint, request, render_template
 

--- a/src/templates/debug_interface.html
+++ b/src/templates/debug_interface.html
@@ -1,0 +1,73 @@
+{% extends "layout.html" %}
+{% block content %}
+<style>
+    .result-form {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+    .result-form > textarea {
+        flex: 1;
+    }
+</style>
+<script type="text/javascript">
+window.submitAssessment = () => {
+    console.log('Submitting');
+
+    const params = new URLSearchParams();
+    params.append('code', document.getElementById('formCode').value);
+    params.append('prompt', document.getElementById('formPrompt').value);
+    params.append('rubric', document.getElementById('formRubric').value);
+
+    const result = document.getElementById('dummyFormResult');
+    result.value = 'Submission sent, please wait...';
+    
+    fetch('/assessment', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: params.toString()
+    })
+    .then(res => res.json())
+    .then(res => {
+        result.value = JSON.stringify(res, null, 2);
+    })
+    .catch(err => {
+        result.value = err;
+    });
+}
+</script>
+
+<br/>
+<h1>Debug Interface<h1>
+<div style="display: flex">
+    <div style="flex: 1">
+
+        <div class="form-group">
+            <label for="formCode">Code</label>
+            <textarea class="form-control" id="formCode" rows="10">{{ code|e }}</textarea>
+        </div>
+
+        <div class="form-group">
+            <label for="formPrompt">Prompt</label>
+            <textarea class="form-control" id="formPrompt" rows="10">{{ prompt|e }}</textarea>
+        </div>
+
+        <div class="form-group">
+            <label for="formRubric">Rubric</label>
+            <textarea class="form-control" id="formRubric" rows="10">{{ rubric|e }}</textarea>
+        </div>
+
+        <br/>
+        <button type="button" class="btn btn-primary btn-lg" onclick="window.submitAssessment()">Submit for Assesment</button>
+    </div>
+
+    <div style="flex: 1; padding-left: 16px">
+        <div class="form-group result-form">
+            <label for="dummyFormResult">Result</label>
+            <textarea class="form-control" id="dummyFormResult">-- waiting for submission --</textarea>
+        </div>
+    </div>
+<div>
+{% endblock %}

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Code.org AI Proxy</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!--TODO: reccomend bundling and delivering via flask-->
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+        <style>
+            :root {
+                --bs-bg: #121212 !important;
+                --bs-text: #FFFFFF !important;
+            }
+        </style>
+        {% block head %}{% endblock %}
+    </head>
+    <body class="bg-dark text-white">
+        <div class="container" data-bs-theme="dark">
+            {% block content %}{% endblock %}
+        </div>
+        {% block body %}{% endblock %}
+    </body>
+</html>


### PR DESCRIPTION
<img width="1255" alt="image" src="https://github.com/tuckersn/aiproxy/assets/8574134/0371a80d-7a36-47cd-bfbf-7e4198a32a9d">
Adds the /debug_interface route, which provides a simple HTML application for testing this service.

Adds the src/templates directory which contains normal Python/Flask templates. This solution requires no additional dependencies or installation, just provides a simple test-interface utilize built-in features and the Bootstrap CDN tags for CSS/JS for styling.

### Alternative Suggestion
- Swagger or OpenAPI: provide API documentation and a web interface to debug using the data provided by that API documentation format, which easily can be added to a static route in flask 
![swagger interface pet example](https://github.com/tuckersn/aiproxy/assets/8574134/f46cfeb7-3af5-431b-8463-7ef5ceec8e93)

### Possible Improvements
- Only enable during development, during production deployments skip the `app.register_blueprint(template_routes)` call
- If I were to add to npm and a bundler like Vite or WebPack, I could add a [VS Code style text editor called Monaco](https://microsoft.github.io/monaco-editor/) for the code prompt 
 ![vs code editor](https://github.com/tuckersn/aiproxy/assets/8574134/c89c812c-bcf9-4992-8239-5c791cb451da)
- Could render the grades as [Bootstrap Cards](https://getbootstrap.com/docs/4.0/components/card/) instead of just a wall of JSON, possibly a 50-50 vertical split between cards and JSON.
- Could detect when / calls are made by a browser and redirect to /debug_interface